### PR TITLE
sct-1: Task images can appear in random or sequential order (depending on type created)

### DIFF
--- a/api/controllers/annotations.js
+++ b/api/controllers/annotations.js
@@ -103,9 +103,20 @@ module.exports = {
         let successMessage = `Annotation of task "${taskData.displayName}" is complete.`;
         throw { congrats : '/success/'+successMessage};
       }
+
       let totalImages = queuedImages.length;
-      let randomIndex = Math.floor(Math.random() * (totalImages - 1));
-      queuedImageData = queuedImages[randomIndex];
+      if (taskData.randomized == false) {
+        let timestamps = {};
+        for (qid of queuedImages) {
+            let images = await Images.find({id : qid.imageId});
+            timestamps[qid.imageId] = images[0].exifTimestamp;
+        }
+        queuedImages.sort(function(a, b) { return timestamps[a.imageId] - timestamps[b.imageId]; });
+        queuedImageData = queuedImages[0];
+      } else {
+          let randomIndex = Math.floor(Math.random() * (totalImages - 1));
+          queuedImageData = queuedImages[randomIndex];
+      }
       this.req.session.annotationHistory[taskData.id].current = queuedImageData.id;
 
     } else {

--- a/api/controllers/api-tasks-get.js
+++ b/api/controllers/api-tasks-get.js
@@ -30,6 +30,9 @@ module.exports = {
     assignee : {
       type : 'string'
     },
+    randomized : {
+      type : 'boolean'
+    },
   },
 
 
@@ -53,6 +56,12 @@ module.exports = {
 
     let query = {};
     // @TODO consolidate with the logic in the app.js csvQueuer worker
+
+    // ordering (randomized)
+
+    if (inputs.randomized != undefined) {
+      query.randomized = inputs.randomized;
+    }
 
     // Name
 

--- a/api/controllers/api-tasks-get.js
+++ b/api/controllers/api-tasks-get.js
@@ -61,10 +61,10 @@ module.exports = {
 
     if (inputs.randomized != undefined) {
       if (inputs.randomized) {
-        query.randomized = true;
+        // this will get previously existing null values (which means randomized)
+        query.randomized = { '!=': false };
       } else {
-        // this will get pre-randomized undefined (null) values as false (sequential)
-        query.randomized = { '!=': true };
+        query.randomized = false;
       }
     }
 

--- a/api/controllers/api-tasks-get.js
+++ b/api/controllers/api-tasks-get.js
@@ -60,7 +60,12 @@ module.exports = {
     // ordering (randomized)
 
     if (inputs.randomized != undefined) {
-      query.randomized = inputs.randomized;
+      if (inputs.randomized) {
+        query.randomized = true;
+      } else {
+        // this will get pre-randomized undefined (null) values as false (sequential)
+        query.randomized = { '!=': true };
+      }
     }
 
     // Name

--- a/api/controllers/api-tasks-post.js
+++ b/api/controllers/api-tasks-post.js
@@ -18,6 +18,11 @@ module.exports = {
       description : 'either a user ID or an ml config name',
       required : true
     },
+    randomized : {
+      type : 'boolean',
+      description : 'shown in random order (vs sequential)',
+      required : true
+    },
     orientation : {
       type : 'string',
       description : 'left or right',
@@ -91,6 +96,7 @@ module.exports = {
         taskType : mlAssignees.hasOwnProperty(inputs.assignee) ? 'ml' : 'user',
         assignee : inputs.assignee,
         orientation : inputs.orientation,
+        randomized : inputs.randomized,
         createdByUserId : this.req.session.userId
       }
 

--- a/api/controllers/ground-truths.js
+++ b/api/controllers/ground-truths.js
@@ -104,8 +104,15 @@ module.exports = {
         throw { congrats : '/success/'+successMessage};
       }
       let totalImages = images.length;
-      let randomIndex = Math.floor(Math.random() * (totalImages - 1));
-      imageData = images[randomIndex];
+
+      // similar to annotations, we can do random or sequential now
+      if (taskData.randomized == false) {
+        images.sort(function(a, b) { return a.exifTimestamp - b.exifTimestamp; });
+        imageData = images[0];
+      } else {
+          let randomIndex = Math.floor(Math.random() * (totalImages - 1));
+          imageData = images[randomIndex];
+      }
       this.req.session.gtHistory[taskData.id].current = imageData.id;
 
     } else {

--- a/api/models/Tasks.js
+++ b/api/models/Tasks.js
@@ -10,7 +10,7 @@ module.exports = {
     progressGroundTruth: { type: 'number', defaultsTo : 0},
     progressLineDivision: { type: 'number', defaultsTo : 0},
     sequencingComplete : {type: 'boolean', defaultsTo : false},
-    randomized : {type: 'boolean', defaultsTo : false},
+    randomized : {type: 'boolean', defaultsTo : true},
     imageCount: { type: 'number', defaultsTo : 0},
     createdByUserId: { type: 'string', required: true }
   }

--- a/api/models/Tasks.js
+++ b/api/models/Tasks.js
@@ -10,6 +10,7 @@ module.exports = {
     progressGroundTruth: { type: 'number', defaultsTo : 0},
     progressLineDivision: { type: 'number', defaultsTo : 0},
     sequencingComplete : {type: 'boolean', defaultsTo : false},
+    randomized : {type: 'boolean', defaultsTo : false},
     imageCount: { type: 'number', defaultsTo : 0},
     createdByUserId: { type: 'string', required: true }
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -402,6 +402,7 @@ let getTaskRow = async (task) => {
   <tr>
     <th scope="row">${task.displayName}</th>
     <td style="text-transform: capitalize">${task.orientation}</td>
+    <td>${task.randomized ? 'rnd' : 'seq'}</td>
     <td>${task.assigneeDiplayName}</td>
     <td>${new Date(task.createdAt).toISOString().split('T')[0]}</td>
     <td>${Math.floor(task.progressAnnotation * 100)}</td>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -408,7 +408,7 @@ let getTaskRow = async (task) => {
   <tr>
     <th scope="row">${task.displayName}</th>
     <td style="text-transform: capitalize">${task.orientation}</td>
-    <td>${task.randomized ? 'rnd' : 'seq'}</td>
+    <td>${task.randomized == false ? 'seq' : 'rnd'}</td>
     <td>${task.assigneeDiplayName}</td>
     <td>${new Date(task.createdAt).toISOString().split('T')[0]}</td>
     <td>${Math.floor(task.progressAnnotation * 100)}</td>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -296,6 +296,12 @@ const getTaskFilters = () => {
     filters.endDate = endDateValue.trim();
   }
 
+  // Randomized (order)
+  let randomizedValue = $('#randomized').val();
+  if(randomizedValue.length){
+    filters.randomized = randomizedValue;
+  }
+
   // Assignee
   let assigneeValue = $('#assigneeInput').val();
   if(assigneeValue.length){
@@ -447,6 +453,7 @@ $('button#taskResetButton').on('click', async (e) =>{
   $('#endDate').val(null);
   $('#assigneeInput').val(null);
   $('#phaseInput').val(null);
+  $('#randomized').val(null);
 
   // Reset pageNumber to 1
   $('#pageNumber').val(1);

--- a/views/pages/tasks-new.ejs
+++ b/views/pages/tasks-new.ejs
@@ -46,10 +46,10 @@
 
         <div class="form-floating">
           <select required class="form-select form-control" name="randomized" id="randomized">
-            <option value="false">false</option>
-            <option value="true">true</option>
+            <option value="false">Sequential</option>
+            <option value="true">Random</option>
           </select>
-          <label for="randomized">Randomized?</label>
+          <label for="randomized">Image ordering</label>
         </div>
 
         <div class="form-floating">

--- a/views/pages/tasks-new.ejs
+++ b/views/pages/tasks-new.ejs
@@ -45,6 +45,14 @@
         </div>
 
         <div class="form-floating">
+          <select required class="form-select form-control" name="randomized" id="randomized">
+            <option value="false">false</option>
+            <option value="true">true</option>
+          </select>
+          <label for="randomized">Randomized?</label>
+        </div>
+
+        <div class="form-floating">
           <fieldset>
             <p class="mt-4">Camera Side</p>
             <div class="row gx-3">

--- a/views/pages/tasks.ejs
+++ b/views/pages/tasks.ejs
@@ -105,6 +105,7 @@
       <tr>
         <th scope="col">Task Name</th>
         <th scope="col">Side</th>
+        <th scope="col">Order</th>
         <th scope="col">Assignee</th>
         <th scope="col">Date Created</th>
         <th scope="col">A%</th>

--- a/views/pages/tasks.ejs
+++ b/views/pages/tasks.ejs
@@ -61,7 +61,7 @@
   </div>
 </div>
 <div class="row">
-  <div class="col-6">
+  <div class="col-4">
     Assignee
     <select class="form-select" size="4" id="assigneeInput" name="assignee" multiple aria-label="multiple select">
 
@@ -84,7 +84,7 @@
 
     </select>
   </div>
-  <div class="col-6">
+  <div class="col-4">
     Stage
     <select id="phaseInput" class="form-select" size="4" multiple aria-label="multiple select">
       <option value="ns">Not started</option>
@@ -94,6 +94,14 @@
       <option value="gf">Ground truth: complete</option>
       <option value="ds">Division: in-progress</option>
       <option value="df">Division: complete</option>
+    </select>
+  </div>
+  <div class="col-4">
+    Ordering type
+    <select id="randomized" class="form-select" aria-label="select">
+      <option value="">Any</option>
+      <option value="false">Sequential</option>
+      <option value="true">Random</option>
     </select>
   </div>
 </div>


### PR DESCRIPTION
* `task.randomized` boolean added to model
* Pulldown for random vs sequential added to _task creation_ screen
* Column for ordering added to _task list_ screen
* Filter by ordering (any, random, sequential) added to _task list_ screen
* _Annotating_ flow follows random or sequential according to task setting
* _Ground-truthing_ flow follows random or sequential according to task setting