### PR TITLE
fix error/death during gm.identify() on bad file

### DIFF
--- a/app.js
+++ b/app.js
@@ -1346,6 +1346,7 @@ const convertToJpg = async (path,filename) => {
     return new Promise((resolve, reject) => {
        gm(path).write(newPath, (err) => {
          if(err){
+           console.log(`Conversion error: ${err}`);
            reject(err);
          } else {
            resolve(newPath)
@@ -1392,7 +1393,8 @@ const parseExif = async (path) => {
   return new Promise((resolve, reject) => {
      gm(path).identify( async (err,data) => {
        if(err){
-         reject(err);
+         console.log(`Identify error: ${err}`);
+         return resolve({});
        } else {
 
          possibleTimestamps = [];

--- a/app.js
+++ b/app.js
@@ -339,7 +339,7 @@ init();
 
 
   }
-  if(ext == 'jpg'){
+  if ((ext == 'jpg') || (ext == 'jpeg')) {
     // move to tmp directory, adding small .jpg extension, get full path of new file
     tempPath = settingsObject.tmpDirectory+'unprocessedImages/'+filename+'.jpg';
     await fs.promises.copyFile(ingestionDir+'/'+randomElement,tempPath);


### PR DESCRIPTION
claims to fix #68 and #73 by capturing failure of `gm.identify()` gracefully.