### PR TITLE
Fix bad sort option on image gallery preview

### DIFF
--- a/views/pages/task-images-preview.ejs
+++ b/views/pages/task-images-preview.ejs
@@ -29,15 +29,17 @@
 	</div>
 
 	<div class="row">
-		<div class="col-6"></div>
 		<div class="col-2">
+			<p><b>Sort by:</b></p>
+		</div>
+		<div class="col-3">
 			<select onChange="window.location = window.location.pathname + '?sortby=' + this.value;" class="form-select form-select-sm form-control" id="sortby" aria-label="select">
-				<option value="">Sort by</option>
 				<option <%=(sortBy=='originalFilenameLower'?'selected':'')%> value="originalFilenameLower">File name</option>
 				<option <%=(sortBy=='exifTimestamp'?'selected':'')%> value="exifTimestamp">Image time/date</option>
 				<option <%=(sortBy=='createdAt'?'selected':'')%> value="createdAt">Time created</option>
 			</select>
 		</div>
+		<div class="col-1"></div>
 		<div class="col-2">
             <button class="btn btn-secondary btn-sm ms-5" type="button" id="imagesPreviewSelectAll">
               Select All


### PR DESCRIPTION
Fixes bad sort option on image gallery

PR fixes #40

**Changes**
- Remove 'sort by' from dropdown options list
- Add label for sort-by dropdown
- Minor layout improvement to better accommodate label

<img width="1296" alt="Screenshot 2024-05-26 at 11 10 37 AM" src="https://github.com/WildMeOrg/scout/assets/67647/6331db43-4030-4640-acbc-dfc7e27d296d">
<img width="1239" alt="Screenshot 2024-05-26 at 11 27 46 AM" src="https://github.com/WildMeOrg/scout/assets/67647/7cd944db-9e74-440e-bf67-14bf56df4b27">

