### PR TITLE
Add GPS coordinates to GT and CSV export

### DIFF
--- a/api/controllers/ground-truths.js
+++ b/api/controllers/ground-truths.js
@@ -173,9 +173,7 @@ module.exports = {
     }
 
 
-
-
-
+    imageData.imageDate = new Date(imageData.exifTimestamp).toLocaleDateString();
 
     let serverData = {
       backEnabled : backEnabled,

--- a/api/models/Images.js
+++ b/api/models/Images.js
@@ -8,7 +8,9 @@ module.exports = {
     exifTimestamp : { type : 'number', required: true },
     fullPath :  { type: 'string', required: true },
     taskIds: { type: 'json', columnType : "array" },
-    gtComplete : { type : 'boolean' , defaultsTo : false}
+    gtComplete : { type : 'boolean' , defaultsTo : false},
+    gpsLatitude: { type: 'number', required: false },
+    gpsLongitude: { type: 'number', required: false },
   },
 
   // definitely would be better done as part of direct query on Images :(

--- a/app.js
+++ b/app.js
@@ -1402,6 +1402,10 @@ const getPossibleTimestampsRecursive = async (obj) =>{
 }
 
 const parseLocation = (data) => {
+  const undefLocation = {
+    latitude: undefined,
+    longitude: undefined
+  }
   const latitudeStr = data?.['Profile-EXIF']?.['GPS Latitude'];
   const longitudeStr = data?.['Profile-EXIF']?.['GPS Longitude'];
   const longRef = data?.['Profile-EXIF']?.["GPS Longitude Ref"];
@@ -1409,10 +1413,7 @@ const parseLocation = (data) => {
 
   // Missing exif data
   if (!latitudeStr || !longitudeStr) {
-    return {
-      latitude: undefined,
-      longitude: undefined
-    }
+    return undefLocation;
   }
 
   // GPS coordinates are formatted as rationals for degrees, minutes, and seconds
@@ -1428,20 +1429,25 @@ const parseLocation = (data) => {
       fractionToDecimal(parts[2]) / 3600; //seconds
   }
 
-  let latDecimal = stringToDecimal(latitudeStr);
-  if (latRef.toLowerCase() === "s") {
-    latDecimal = -1 * latDecimal;
-  }
+  try {
+    let latDecimal = stringToDecimal(latitudeStr);
+    if (latRef.toLowerCase().startsWith("s")) {
+      latDecimal = -1 * latDecimal;
+    }
 
-  let longDecimal = stringToDecimal(longitudeStr);
+    let longDecimal = stringToDecimal(longitudeStr);
 
-  if (longRef.toLowerCase() === "w") {
-    latDecimal = -1 * longDecimal;
-  }
-  return {
-    latitude: Number.parseFloat(latDecimal).toFixed(6),
-    longitude: Number.parseFloat(longDecimal).toFixed(6)
-  }
+    if (longRef.toLowerCase().startsWith("w")) {
+      latDecimal = -1 * longDecimal;
+    }
+    return {
+      latitude: Number.parseFloat(latDecimal).toFixed(6),
+      longitude: Number.parseFloat(longDecimal).toFixed(6)
+    }
+  } catch {
+    console.log("EXIF location data exists but failed to parse")
+  } 
+  return undefLocation;
 }
 
 const parseExif = async (path) => {

--- a/views/pages/ground-truths.ejs
+++ b/views/pages/ground-truths.ejs
@@ -2,7 +2,6 @@
 <div class="container d-flex justify-content-center">
 
   <div>
-    
     <div class = "labelBanner">        
       <p>Use keyboard shortcuts to switch to the desired label.</p>
       <div>Current active label is: </div>
@@ -11,12 +10,21 @@
     </div>
     <div class = "hotKeyBox" id = "hotKeyBox">
       <p>Shortcut Keys</p>        
-    </div>      
+    </div>
+    <div>
+      <p>
+        <small>
+          Date: <%=imageData.imageDate%><br>
+          Latitude: <% if(imageData.gpsLatitude){ %><%=imageData.gpsLatitude%><% }else{ %>unavailable<% } %><br>
+          Longitude: <% if(imageData.gpsLongitude){ %><%=imageData.gpsLongitude%><% }else{ %>unavailable<% } %>
+        </small>
+      </p>
+    </div>
     <div class="toggle-switch">
       <input type="checkbox" id="toggle-switch" checked>
       <label for="toggle-switch">Show Labels</label>
     </div>
- 
+
 </div>
 
   <div class="sbsRow">
@@ -38,7 +46,6 @@
     </div>
 
     <div style="float: clear">&nbsp;</div>
-
 
   </div>
 


### PR DESCRIPTION
Parse GPS from EXIF data and plumb it through to the UI and CSV exporter

PR fixes #83

**Changes**
- Add GPS parser function to grab exif data and convert to decimal
- Add lat+long to the Images model
- Add a small metadata section to the GT sidebar with date, lat, long (or 'unavailable')
- Add lat, long, and date to the CSV export

Note the ticket specifies putting the metadata in the upper left corner, but I thought this information would be too crowded up there. Open to suggestions for how to format this.

Screenshots:
New CSV export:
<img width="1412" alt="Screenshot 2024-06-01 at 3 18 50 PM" src="https://github.com/WildMeOrg/scout/assets/67647/e16bef20-74a8-4002-a613-a02243b4645e">

Image with location data:
<img width="1448" alt="Screenshot 2024-06-01 at 3 44 43 PM" src="https://github.com/WildMeOrg/scout/assets/67647/4737ebc6-f295-45c9-a200-a678c7ef908b">

Image without location data:
<img width="1474" alt="Screenshot 2024-06-01 at 3 17 51 PM" src="https://github.com/WildMeOrg/scout/assets/67647/ff66bc25-76b1-4878-97b2-4ea6ff3c4227">
