### PR TITLE
Add form validation for location filters in image selection modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,7 +271,6 @@ const init = async () => {
     await startWorkers();
   }
 
-
 };
 
 init();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1065,7 +1065,13 @@ $('#imageSelectionModalTrigger').on('click',(e) =>{
 
 $('#imageSelectionFormSubmit').on('click',(e) => {
   e.preventDefault();
-  
+  const imageSelectionForm = document.getElementById('imageSelectionForm');
+  if (!imageSelectionForm.checkValidity()) {
+    imageSelectionForm.reportValidity();
+    return;
+  }
+
+
   // Save the state of the form and filtered result
   window.imageSelectionFormSavedCount = window.imageSelectionFormUnsavedCount;
   window.imageSelectionFormSavedInputs = window.imageSelectionFormUnsavedInputs;

--- a/views/pages/tasks-new.ejs
+++ b/views/pages/tasks-new.ejs
@@ -208,21 +208,25 @@
                 <div class="row gx-3">
                   <div class="form-floating col-6">
                     <input
-                      type="text"
+                      type="number"
                       class="form-control"
                       name="latMin"
                       id="latMin"
                       placeholder="-90"
+                      min=-90
+                      max=90
                     />
                     <label for="floatingInput">From</label>
                   </div>
                   <div class="form-floating col-6">
                     <input
-                      type="text"
+                      type="number"
                       class="form-control"
                       name="latMax"
                       id="latMax"
                       placeholder="90"
+                      min=-90
+                      max=90
                     />
                     <label for="floatingInput">To</label>
                   </div>
@@ -235,21 +239,25 @@
                 <div class="row gx-3">
                   <div class="form-floating col-6">
                     <input
-                      type="text"
+                      type="number"
                       class="form-control"
                       name="longMin"
                       id="longMin"
                       placeholder="-180"
+                      min=-180
+                      max=180
                     />
                     <label for="floatingInput">From</label>
                   </div>
                   <div class="form-floating col-6">
                     <input
-                      type="text"
+                      type="number"
                       class="form-control"
                       name="longMax"
                       id="longMax"
                       placeholder="180"
+                      min=-180
+                      max=180
                     />
                     <label for="floatingInput">To</label>
                   </div>
@@ -261,7 +269,7 @@
             <div
               class="input-group mb-3" >
               <div class="form-floating">
-                <select size="5" required class="form-select form-control" multiple name="labels" id="labels" aria-label="multiple select">
+                <select size="5" class="form-select form-control" multiple name="labels" id="labels" aria-label="multiple select">
                   <% for (const labelName of allLabelNames) { %>
                     <option><%=labelName%></option>
                   <% } %>


### PR DESCRIPTION
The image selection modal has some custom submission behavior. On image selection modal submit, grab the form and manually validate. Uses the default browser validation UI, which appears to be what we're doing elsewhere.

**Changes**
- Adds min values to lat+long input fields
- Manually validate upon submission
<img width="514" alt="Screenshot 2024-06-19 at 12 09 05 PM" src="https://github.com/WildMeOrg/scout/assets/67647/87ca33c8-9946-4eca-a9f1-a078b67cd8bf">
