### PR TITLE
cuda:12.2.2 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu20.04
 
 # BEGIN SCOUTBOT SETUP
 


### PR DESCRIPTION
cuda:12.2.2 upgrade ubuntu20.04

DEPRECATION NOTICE from NVIDIA as the 11X versions 

**Changes**
- Docker file has changed with 12.2 CUDA version upgrade
