### PR TITLE
Update Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN set -ex \
  && rm -rf /var/cache/apt \
  && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get -y update
-RUN apt-get -y install git
+RUN apt-get -y update && \
+    apt-get -y install git && \
+    apt-get clean  
 RUN pip install git+https://github.com/WildMeOrg/scoutbot.git --timeout=100
 
 RUN pip3 uninstall -y onnxruntime


### PR DESCRIPTION
Cleanup apt cache to fix the dockerhub build EnvironmentError: [Errno 28] No space left on device on Docker

[Plain-text summary description of the solution]

PR fixes #[REPLACE WITH ISSUE NUMBER]

**Changes**
- [bullet list include any model updates]
- [new or edited functions]
- [significant changes to UX]
- [design decisions, especially if architectural patterns are new/altered]
- [can use text, screenshots, or files]
- [a callout of any ##TODO or ##FIXMEs found/created as part of the fix]
