### PR TITLE
sort hotkey labels to be numerical

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -862,6 +862,7 @@ if(!document.querySelector("#activeLabel")) {
       allOptions.push("shft+"+count);
       count++;
     }    
+    allOptions.sort();
     return allOptions;    
   }
 


### PR DESCRIPTION
hotkey labels were displaying as interleaved sort; updated to be numerical then shit numerical

PR fixes #39 

**Changes**
- simple sort addition