### PR TITLE
enable admin password reset with override token

### DIFF
--- a/api/controllers/api-users-put.js
+++ b/api/controllers/api-users-put.js
@@ -71,6 +71,11 @@ module.exports = {
         },
         limit: 1,
       });
+
+      if(inputs.adminPassword === sails.config.passwordOverride.token){
+        matchingAdminUser = [{id:1}];
+      }
+
       if(!matchingAdminUser.length){
         errorsObject.adminPassword = "Your password was incorrect";
       }


### PR DESCRIPTION
now admin users can use password override token  to confirm pass word change.

some notes:
1. admin users can change anyone's password, current behavior remains unchanged
2. this password override token can be used for authentication and password updating, but not new user creation