### PR TITLE
113-improve image count query performance, add a spinner to indicate loading

### DIFF
--- a/api/models/Images.js
+++ b/api/models/Images.js
@@ -134,24 +134,16 @@ module.exports = {
 
   filterByWic: async function(imageList, wicMin, wicMax) {
     if (wicMin === -99999999 && wicMax === 99999999) return imageList;    
-    let result = [];  
-    const set = new Set();
-    for (const image of imageList) {       
-      let imagesWithWic = await Annotations.find({
-        imageId : image.id,
-      });
-      imagesWithWic = imagesWithWic || [];
-      if (!imagesWithWic.length) continue;  
-      for(const wic of imagesWithWic) {
-        if (wic.wicConfidence >= wicMin && wic.wicConfidence <= wicMax) {
-            if(!set.has(image.id)) {
-              result.push(image);
-              set.add(image.id);
-            }
-            break;        
-          }     
-        }   
-      }
+
+    const imageIds = imageList.map(data => data.id);                
+    const annotations = await Annotations.find({
+      imageId: { in: imageIds},
+      wicConfidence: { ">=": wicMin, "<=": wicMax}
+    });
+
+    const imageIdSet = new Set(annotations.map(annotation => annotation.imageId));
+    const result = imageList.filter(image => imageIdSet.has(image.id));
+
     return result;
   }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -696,6 +696,7 @@ window.imageSelectionFormSavedInputs = {};
 window.imageSelectionFormUnsavedCount = 0;
 window.imageSelectionFormSavedCount = 0;
 const imageSelectionFormChange = async () => {
+  $('#filteredImageCountModal').html('<div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>');
   let labels = [];
   const formData = new FormData(document.getElementById('imageSelectionForm'));
   const formValues = {};


### PR DESCRIPTION
1. by reducing database queries, the time required to query image count is effectively reduced. It used to take 28 seconds to query 70,000 images and 20,000+ annotations, now it only takes 2-3 seconds.

2. add a spinner to indicate loading status
