### PR TITLE
fix an annotation display issue caused by new feature(zoom)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1206,6 +1206,7 @@ function zoomAnnotationImage(factor, mouseX = window.imageHeight/2, mouseY= wind
   wrapper.scrollTop(newScrollTop);
 
   window.imageHeight = newHeight;
+  simpleBoxes.zoom(window.sbHandle1.id);
 }
 
 // Bind back button


### PR DESCRIPTION
fix an issue caused by the new zoom feature: we need to sync canvas while zooming pictures or else annotations display in wrong place

PR does not fix numbered issue