### PR TITLE
107 image grid

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1212,7 +1212,7 @@ $('#annotationInnerWrapper').on('wheel', (e) => {
 function zoomAnnotationImage(factor, mouseX = window.imageHeight/2, mouseY= window.imageHeight/2) {
   const image = $('#imageToAnnotate');
   const wrapper = $('#annotationInnerWrapper');
-
+  const gridOverlay = $('.gridOverlay');
   const oldImageWidth = image.width();
   const oldImageHeight = image.height();
 
@@ -1247,6 +1247,14 @@ function zoomAnnotationImage(factor, mouseX = window.imageHeight/2, mouseY= wind
   image.css({
     height: newHeight + 'px',
     width: newWidth + 'px'
+  });
+
+  const gridBaseSize = 100; 
+  const gridScale = newHeight / minimumImageHeight; 
+  let newGridSize = Math.max(gridBaseSize * gridScale, 100);
+
+  gridOverlay.css({
+    backgroundSize: `${newGridSize}px ${newGridSize}px`
   });
 
   wrapper.scrollLeft(newScrollLeft);
@@ -1392,7 +1400,7 @@ setTimeout( async () => {
 const zoomGroundTruthImage = (factor, mouseX = window.imageHeight/2, mouseY= window.imageHeight/2) => {
   const image = $('#imageToGroundTruth');
   const wrapper = $('#scrollBoxLeft'); // Wrapper for scroll handling
-
+  const gridOverlay = $('.gridOverlay');
   const oldImageWidth = image.width();
   const oldImageHeight = image.height();
 
@@ -1428,6 +1436,14 @@ const zoomGroundTruthImage = (factor, mouseX = window.imageHeight/2, mouseY= win
     image.css({
       height: newHeight + 'px',
       width: newWidth + 'px'
+    });
+
+    const gridBaseSize = 100; 
+    const gridScale = newHeight / minimumImageHeight; 
+    let newGridSize = Math.max(gridBaseSize * gridScale, 100);
+
+    gridOverlay.css({
+      backgroundSize: `${newGridSize}px ${newGridSize}px`
     });
 
     wrapper.scrollLeft(newScrollLeft);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -80,6 +80,18 @@ $( document ).ready( async () => {
       }   
   }); 
 
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'g' || e.key === 'G') {
+      const gridSwitch = document.querySelector('.gridswitch');
+      if (gridSwitch) {
+        // Toggle the grid switch checked state
+        gridSwitch.checked = !gridSwitch.checked;
+        // Trigger the change event manually
+        $(gridSwitch).trigger('change');
+      }
+    }
+  });
+
 $('form.handleable').each(function(index) {
 
   $(this).submit(async function(e){

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,6 +67,19 @@ window.debugAnnotations = async () =>{
 
 $( document ).ready( async () => {  
 
+  $('body').on('change', '.gridswitch', async (e) => {      
+      const gridOverlays = document.querySelectorAll('.gridOverlay');
+      if (e.target.checked) {
+        gridOverlays.forEach(gridOverlay => {
+          gridOverlay.style.display = 'block';
+      });
+      } else {
+        gridOverlays.forEach(gridOverlay => {
+          gridOverlay.style.display = 'none';
+      }); 
+      }   
+  }); 
+
 $('form.handleable').each(function(index) {
 
   $(this).submit(async function(e){
@@ -142,6 +155,8 @@ $('form.handleable').each(function(index) {
     }
 
   });
+
+  
 
 });
 
@@ -2058,5 +2073,4 @@ window.imagesDelete = async (imageIds) => {
         imageIds: imageIds
     };
 }
-
 

--- a/assets/simple-boxes.css
+++ b/assets/simple-boxes.css
@@ -32,17 +32,8 @@
   position: relative;
 }
 
-#innerWrapperLeft{
-  position: relative;
-}
-
-#innerWrapperRight{
-  position: relative;
-}
-
 .gridOverlay {
-  /* display: none; Hidden by default */
-  border: 1px solid rgba(0, 0, 255, 0.8);
+  display: none; 
   z-index: 1000;
   position: absolute;
   top: 0;
@@ -51,8 +42,8 @@
   height: 100%;
   pointer-events: none; /* Makes grid non-interactive */
   background-size: 100px 100px;
-  background-image: linear-gradient(to right, rgba(0, 0, 255, 0.8) 2px, transparent 2px),
-                    linear-gradient(to bottom, rgba(0, 0, 255, 0.8) 2px, transparent 2px);
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.9) 1px, transparent 1px),
+                    linear-gradient(to bottom, rgba(255, 255, 255, 0.9) 1px, transparent 1px);
 }
 
 #imageToBox{

--- a/assets/simple-boxes.css
+++ b/assets/simple-boxes.css
@@ -12,8 +12,47 @@
 
 .simpleBoxesImageAndCanvasWrapper{
   position: relative;
+  display: inline-block;
   top: 0;
   left: 0;
+}
+
+#annotationOuterWrapper{
+  position: relative;
+  display: inline-block;
+  top: 0;
+  left: 0;
+}
+
+#gtColumnLeft{
+  position: relative;
+}
+
+#gtColumnRight{
+  position: relative;
+}
+
+#innerWrapperLeft{
+  position: relative;
+}
+
+#innerWrapperRight{
+  position: relative;
+}
+
+.gridOverlay {
+  /* display: none; Hidden by default */
+  border: 1px solid rgba(0, 0, 255, 0.8);
+  z-index: 1000;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none; /* Makes grid non-interactive */
+  background-size: 100px 100px;
+  background-image: linear-gradient(to right, rgba(0, 0, 255, 0.8) 2px, transparent 2px),
+                    linear-gradient(to bottom, rgba(0, 0, 255, 0.8) 2px, transparent 2px);
 }
 
 #imageToBox{

--- a/assets/simple-boxes.js
+++ b/assets/simple-boxes.js
@@ -1028,6 +1028,19 @@ $( document ).ready(function() {
     }
   });
 
+  $('body').on('change', '.gridswitch', async (e) => {      
+      const gridOverlays = document.querySelectorAll('.gridOverlay');
+      if (e.target.checked) {
+        gridOverlays.forEach(gridOverlay => {
+          gridOverlay.style.display = 'block';
+      });
+      } else {
+        gridOverlays.forEach(gridOverlay => {
+          gridOverlay.style.display = 'none';
+      }); 
+      }   
+  });
+
   // resize of source image
 
   // Pan and zoom of source image

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -168,8 +168,32 @@ tr:hover .tag-edit-button {
 
 #ldBoxLeft{
   position: relative;
+  display: inline-block;
   top: 0;
   left: 0;
+}
+
+
+#ldBoxRight{
+  position: relative;
+  display: inline-block;
+  top: 0;
+  left: 0;
+}
+
+.gridOverlay {
+  /* display: none; Hidden by default */
+  border: 1px solid rgba(0, 0, 255, 0.8);
+  z-index: 1000;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none; /* Makes grid non-interactive */
+  background-size: 100px 100px;
+  background-image: linear-gradient(to right, rgba(0, 0, 255, 0.8) 2px, transparent 2px),
+                    linear-gradient(to bottom, rgba(0, 0, 255, 0.8) 2px, transparent 2px);
 }
 
 #imageToLineDraw{

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -182,8 +182,7 @@ tr:hover .tag-edit-button {
 }
 
 .gridOverlay {
-  /* display: none; Hidden by default */
-  border: 1px solid rgba(0, 0, 255, 0.8);
+  display: none; 
   z-index: 1000;
   position: absolute;
   top: 0;
@@ -192,8 +191,8 @@ tr:hover .tag-edit-button {
   height: 100%;
   pointer-events: none; /* Makes grid non-interactive */
   background-size: 100px 100px;
-  background-image: linear-gradient(to right, rgba(0, 0, 255, 0.8) 2px, transparent 2px),
-                    linear-gradient(to bottom, rgba(0, 0, 255, 0.8) 2px, transparent 2px);
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.9) 1px, transparent 1px),
+                    linear-gradient(to bottom, rgba(255, 255, 255, 0.9) 1px, transparent 1px);
 }
 
 #imageToLineDraw{

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -140,7 +140,7 @@
             <div class="btn-group">
               <button id="annotationZoomIn" class="btn btn-light"><i class="bi-zoom-in"></i></button>
               <button id="zoomLevel" class="btn btn-light">0%</button>
-              <button id="annotationZoomOut" class="btn btn-light"><i class="bi-zoom-out"></i></button>
+              <button id="annotationZoomOut" class="btn btn-light"><i class="bi-zoom-out"></i></button>              
               <button
                 type="button"
                 class="btn btn-light"
@@ -151,6 +151,12 @@
                 <p>Click an existing annotation to adjust or edit the annotation.</p>"
                 data-toggle="popover">
                 <i class="bi-info-circle"></i>
+              </button>
+              <button class="btn btn-light">
+                <div class="grid-switch form-check form-switch align-items-center justify-content-center">
+                  <input class="form-check-input gridswitch" type="checkbox" id="switch" >
+                  <label class = "form-check-label" id="annotationswitch" for="annotationswitch">Grid</label>
+                </div>
               </button>
 
             </div>
@@ -186,6 +192,12 @@
                   <p>Click an existing annotation to adjust or edit the annotation.</p>"
                   data-toggle="popover">
                   <i class="bi-info-circle"></i>
+                </button>
+                <button class="btn btn-light">
+                  <div class="grid-switch form-check form-switch align-items-center justify-content-center">
+                    <input class="form-check-input gridswitch" type="checkbox" id="gtswitch1" >
+                    <label class = "form-check-label" id="gtswitch1" for="gtswitch1">Grid</label>
+                  </div>
                 </button>
 
               </div>
@@ -223,6 +235,12 @@
                   <p>Click an existing annotation to adjust or edit the annotation.</p>"
                   data-toggle="popover">
                   <i class="bi-info-circle"></i>
+                </button>
+                <button class="btn btn-light">
+                  <div class="grid-switch form-check form-switch align-items-center justify-content-center">
+                    <input class="form-check-input gridswitch" type="checkbox" id="gtswitch2" >
+                    <label class = "form-check-label" id="gtswitch2" for="gtswitch2">Grid</label>
+                  </div>
                 </button>
 
 
@@ -265,16 +283,26 @@
                 <button id="divisionBack" <% if(!backEnabled) { %>disabled<% } %>  class="btn btn-primary">
                   <i class="bi-chevron-left"></i>
                 </button>
-                <div id="lineOpenerWrapper" class="btn-group">
-                  <button id="lineOpener" class="btn btn-light">
-                    <i class="bi-slash-square"></i>
+                <div class="justify-content-center d-flex flex-row">
+                  <div id="lineOpenerWrapper" class="btn-group">
+                    <button id="lineOpener" class="btn btn-light">
+                      <i class="bi-slash-square"></i>
+                    </button>
+                  </div>
+                
+                  <div id="lineCloserWrapper" class="btn-group">
+                    <button id="lineCloser" class="btn btn-light active">
+                      <i class="bi-slash-square"></i>
+                    </button>
+                  </div>
+                  <button class="btn btn-light">
+                    <div class="grid-switch form-check form-switch align-items-center justify-content-center">
+                      <input class="form-check-input gridswitch" type="checkbox" id="dlswitch" >
+                      <label class = "form-check-label" id="dlswitch" for="dlswitch">Grid</label>
+                    </div>
                   </button>
                 </div>
-                <div id="lineCloserWrapper" class="btn-group">
-                  <button id="lineCloser" class="btn btn-light active">
-                    <i class="bi-slash-square"></i>
-                  </button>
-                </div>
+                
                 <button id="divisionDone" class="btn btn-primary">
                   Done <i class="bi-chevron-right"></i>
                 </button>

--- a/views/pages/annotations.ejs
+++ b/views/pages/annotations.ejs
@@ -21,12 +21,11 @@
       </div>
    
   </div>
-    <div id="annotationOuterWrapper">   
-      <div class="gridOverlay"></div> 
+    <div id="annotationOuterWrapper">         
       <div id="annotationInnerWrapper">        
         <div class="simpleBoxesImageAndCanvasWrapper">
-          <img id="imageToAnnotate" src="/uploads/<%=imageData.id %>" />
-          
+          <div class="gridOverlay"></div> 
+          <img id="imageToAnnotate" src="/uploads/<%=imageData.id %>" />          
         </div>
       </div>
     </div>

--- a/views/pages/annotations.ejs
+++ b/views/pages/annotations.ejs
@@ -21,10 +21,12 @@
       </div>
    
   </div>
-    <div id="annotationOuterWrapper">    
-      <div id="annotationInnerWrapper">
+    <div id="annotationOuterWrapper">   
+      <div class="gridOverlay"></div> 
+      <div id="annotationInnerWrapper">        
         <div class="simpleBoxesImageAndCanvasWrapper">
-        <img id="imageToAnnotate" src="/uploads/<%=imageData.id %>" />
+          <img id="imageToAnnotate" src="/uploads/<%=imageData.id %>" />
+          
         </div>
       </div>
     </div>

--- a/views/pages/ground-truths.ejs
+++ b/views/pages/ground-truths.ejs
@@ -32,19 +32,19 @@
 
   <div class="sbsRow">
 
-    <div   id="gtColumnLeft" style="width: 100%; float: clear; text-align: center;">
-      <div class="gridOverlay"></div> 
+    <div   id="gtColumnLeft" style="width: 100%; float: clear; text-align: center;">      
       <div id="scrollBoxLeft" class="groundTruthInnerWrapper">
         <div class="simpleBoxesImageAndCanvasWrapper">
-        <img class = "imageToGroundTruth" id="imageToGroundTruth" src="/uploads/<%=imageData.id %>"/>
+          <div class="gridOverlay"></div> 
+          <img class = "imageToGroundTruth" id="imageToGroundTruth" src="/uploads/<%=imageData.id %>"/>
         </div>
       </div>
     </div>
 
-    <div  id="gtColumnRight" style="width: 49.8%; float: right; text-align: left;">
-      <div class="gridOverlay"></div> 
+    <div  id="gtColumnRight" style="width: 49.8%; float: right; text-align: left;">      
       <div id="scrollBoxRight" class="groundTruthInnerWrapperReadOnly">
         <div class="simpleBoxesImageAndCanvasWrapper">
+          <div class="gridOverlay"></div> 
         <img class = "imageToGroundTruth" id="imageComparison" src="/uploads/<%=imageData.id %>/?right=true">
         </div>
       </div>

--- a/views/pages/ground-truths.ejs
+++ b/views/pages/ground-truths.ejs
@@ -33,6 +33,7 @@
   <div class="sbsRow">
 
     <div   id="gtColumnLeft" style="width: 100%; float: clear; text-align: center;">
+      <div class="gridOverlay"></div> 
       <div id="scrollBoxLeft" class="groundTruthInnerWrapper">
         <div class="simpleBoxesImageAndCanvasWrapper">
         <img class = "imageToGroundTruth" id="imageToGroundTruth" src="/uploads/<%=imageData.id %>"/>
@@ -41,6 +42,7 @@
     </div>
 
     <div  id="gtColumnRight" style="width: 49.8%; float: right; text-align: left;">
+      <div class="gridOverlay"></div> 
       <div id="scrollBoxRight" class="groundTruthInnerWrapperReadOnly">
         <div class="simpleBoxesImageAndCanvasWrapper">
         <img class = "imageToGroundTruth" id="imageComparison" src="/uploads/<%=imageData.id %>/?right=true">

--- a/views/pages/line-divisions.ejs
+++ b/views/pages/line-divisions.ejs
@@ -16,16 +16,18 @@
       />
     </div>
     <div style="clear: both; height: 1px;">&nbsp;</div>
-    <div class=""  id="ldColumnLeft" style="width: 49.8%; float: left; text-align: right;">
-      <div id="ldBoxLeft" class="ldBoxInnerWrapper">
-        <img id="imageToLineDraw" src="/uploads/<%=imageLeftId %>"/>
-      </div>
+    <div class=""  id="ldColumnLeft" style="width: 49.8%; float: left; text-align: right;">         
+        <div id="ldBoxLeft" class="ldBoxInnerWrapper">
+            <div class="gridOverlay"></div>   
+            <img id="imageToLineDraw" src="/uploads/<%=imageLeftId %>"/>
+        </div>
     </div>
 
-    <div class="" id="ldColumnRight" style="width: 49.8%; float: right; text-align: left;">
-      <div id="ldBoxRight" class="ldBoxInnerWrapper">
-        <img id="lineDrawNextImage" src="/uploads/<%=imageRightId %>">
-      </div>
+    <div class="" id="ldColumnRight" style="width: 49.8%; float: right; text-align: left;">        
+        <div id="ldBoxRight" class="ldBoxInnerWrapper">
+            <img id="lineDrawNextImage" src="/uploads/<%=imageRightId %>">
+            <div class="gridOverlay"></div> 
+        </div>
     </div>
 
     <div style="clear: both;  height: 1px;">&nbsp;</div>


### PR DESCRIPTION
add grid on images of annotation/groundtruth/division line

- toggle (off by default) labeled "grid"
- toggled can be clicked or activated with 'g'
- when on, grid toggle creates a grid overlay on the image
- grid is 100x100 squares with excess in final row/column
- grid lines extend from top to bottom and left to right
- toggle can trigger on and off
- grid adjusts with zoom

PR fixes #107 