### PR TITLE
fix label selector dropdown list unexpected closed issue

### DIFF
--- a/assets/simple-boxes.js
+++ b/assets/simple-boxes.js
@@ -492,6 +492,7 @@ window.simpleBoxes._.methods = {
 
     if (!handleId) return;
     if (e.target && e.target.classList.contains('annotationBox')) return;
+    if (e.target && e.target.classList.contains('labelSelector')) return;
   
     const fakeEvent = {
       target: { id: handleId },


### PR DESCRIPTION
when mouse is on label selector, don't send fake event to handleMouseUp, because handleMouseUp will redraw all boxes and hence label selector dropdown will be closed